### PR TITLE
Set context.session.echo, so the example works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ DialogManager.add('step_1', {
     "What is the message that you'd like me to echo back?"
   ],
   onresponse: function(context, event, callback) {
-    context.echo = event.message;
+    context.session.echo = event.message;
     DialogManager.dialogs.step_2.play(context, event, callback);
   }
 });
@@ -60,7 +60,7 @@ DialogManager.add('step_2', {
     "You told me to echo \"{echo}\""
   ],
   after: function(context, event, callback) {
-    delete context.echo;
+    delete context.session.echo;
     DialogManager.dialogs.step_1.play(context, event, callback);
   }
 });


### PR DESCRIPTION
Nice example!

I noticed it failed to echo the input string, and instead said `bot > You told me to echo "{echo}"`.

This should fix it by setting the `echo` property on `context.session` instead of directly on `context`.